### PR TITLE
Add option to skip process lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/bastjan/netstat
 
 require github.com/google/go-cmp v0.2.0
+
+go 1.13


### PR DESCRIPTION
Adds the option `netstat.SkipProcessLookup` to skip the rather slow PID lookup